### PR TITLE
compilation fix for macOS

### DIFF
--- a/inc/gui/drawable_tree_builder.h
+++ b/inc/gui/drawable_tree_builder.h
@@ -5,6 +5,9 @@
 #include "drawable.h"
 #include "../util/tree_builder.h"
 
+// macOS defined OVERFLOW, but it is used here as an enum case name
+#undef OVERFLOW
+
 namespace SDL_GUI {
 /** types of Drawables to build */
 enum class Type {


### PR DESCRIPTION
Some header on macOS defines `OVERFLOW`, so explicitly undefined it here. Otherwise, the enum case called `OVERFLOW` does not compile. I have not tested, whether this affects compilation on Linux. If it does, then please wrap the `#undef` line with `#ifdef __APPLE__`.